### PR TITLE
READMEに技術記事投稿サイトの情報を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# Ishikawa-Taiki.github.io
+# プロフィール
+
+TODO
+
+# リンク(エンジニアリング関連)
+
+利用している外部サービスのアカウントは以下の通り。
+
+| 外部サービス名 | アカウントリンク                                         | 現在の主な用途                                         |
+|-----------------|----------------------------------------------------------|---------------------------------------------------------|
+| GitHub          | [@Ishikawa-Taiki](https://github.com/Ishikawa-Taiki)     | コード/設定の管理(現状プライベート利用のみ)           |
+| AtCoder         | [@IshikawaTaiki](https://atcoder.jp/users/IshikawaTaiki) | 関数型プログラミング(Haskell)、アルゴリズム学習       |
+| Zenn            | [@ishikawa_taiki](https://zenn.dev/ishikawa_taiki)       | 調査や思想のメモ、自身の体系的な情報整理              |
+| Qiita           | [@ishikawa_taiki](https://qiita.com/ishikawa_taiki)      | 有用そうな情報のまとめ                                 |
+
+技術記事投稿サイト(Zenn/Qiita)については、サービス上の機能やユーザー数等を踏まえて以下構想で運用する想定。(運用前のため変更する可能性あり)
+
+```
+[Zenn]scraps：
+ 気軽に日々メモとして残したいもの。
+ 解決するなど、進展がなくなったらクローズする想定。
+[Zenn]articles/books：
+ 自分なりに体系立てて理解を纏めたり、情報発信したいもの。
+ 個人的に関心の強い領域のものが中心となる想定。
+[Qiita]記事：
+ 一応纏めておくことで、人のためになりそうなもの。(自分含む)
+ 上記には含まれない単体のものや、要点だけ抜粋した情報が中心となる想定。
+
+```
+
+# 更新
+
+最終更新：2024/07/27
+[履歴](https://github.com/Ishikawa-Taiki/ishikawa-taiki.github.io/commits/main/)


### PR DESCRIPTION
技術記事投稿サイトを活用開始してみたいため、READMEに情報を追加する
(情報の基点として本ページを運用したいため、自身に関する情報変化は適宜反映する)
